### PR TITLE
fix: support previewing non-published pages

### DIFF
--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -25,7 +25,7 @@ export const getStaticProps: GetStaticProps<{ preview?: boolean }> = async conte
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const paths = await getPathsFromProjectMap({ skipPath: ProductPagesPrefixes.ProductListPage });
-  return { paths, fallback: false };
+  return { paths, fallback: true };
 };
 
 export default CommonContainer;

--- a/src/pages/products/[slug].tsx
+++ b/src/pages/products/[slug].tsx
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     ? products.map((product: Type.Product) => `${ProductPagesPrefixes.ProductDetailsPage}/${product.slug}`)
     : [];
 
-  return { paths, fallback: false };
+  return { paths, fallback: true };
 };
 
 export default CommonContainer;

--- a/src/pages/shop/[category].tsx
+++ b/src/pages/shop/[category].tsx
@@ -30,7 +30,7 @@ export const getStaticProps: GetStaticProps<{ preview?: boolean }> = async conte
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const paths = await getPathsFromProjectMap({ path: ProductPagesPrefixes.ProductListPage });
-  return { paths, fallback: false };
+  return { paths, fallback: true };
 };
 
 export default CommonContainer;

--- a/src/pages/shop/[category]/[subcategory].tsx
+++ b/src/pages/shop/[category]/[subcategory].tsx
@@ -39,7 +39,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     path: ProductPagesPrefixes.ProductListPage,
   });
   const paths = getAvailableSubCategoriesPaths(baseCategoriesPaths, categories);
-  return { paths, fallback: false };
+  return { paths, fallback: true };
 };
 
 export default CommonContainer;


### PR DESCRIPTION
This should allow folks to preview newly created pages in Visual Canvas, without the need for publishing the page.